### PR TITLE
Specify unique short name for image_ob argument

### DIFF
--- a/src/bin/test_ob_service.rs
+++ b/src/bin/test_ob_service.rs
@@ -22,7 +22,7 @@ struct Args {
     image: Option<String>,
 
     /// Save image with boundary bbox
-    #[clap(short, long)]
+    #[clap(short = 'I', long)]
     image_ob: Option<String>,
 
     /// Number of requests to make


### PR DESCRIPTION
There were conflicting short names between 'image' and 'image_ob' resulting in runtime panic 'Short option names must be unique for each argument'. This simply sets the short name of `image_ob` as "I", keeping `image` as "i".

```sh
thread 'main' panicked at /home/mosthated/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/src/builder/debug_asserts.rs:112:17:
Command blue-candle: Short option names must be unique for each argument, but '-i' is in use by both 'image' and 'image_ob'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```